### PR TITLE
fix: skip auto-formatting JSON inputs

### DIFF
--- a/tests/js/auto-formatter.test.js
+++ b/tests/js/auto-formatter.test.js
@@ -55,6 +55,24 @@ describe('AutoFormatter Functions', () => {
             expect(shouldAutoFormat(jsonText, mockNodeInfo('SimpleChatTextInput', 'text'))).toBe(false);
         });
 
+        test('should return true for prompts containing comfyui-prompt-control scheduling syntax', () => {
+            // Range expression: [before:during:after:start,end]
+            expect(shouldAutoFormat('[black::white:0.3,0.7], 1girl, blue hair', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
+
+            // Alternating: [a|b:pct]
+            expect(shouldAutoFormat('[cat|dog:0.1], 1girl, solo', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
+
+            // Sequence: [SEQ:a:N1:b:N2:...]
+            expect(shouldAutoFormat('[SEQ:red:0.3:blue:0.6:green:0.9], 1girl', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
+
+            // LoRA scheduling
+            expect(shouldAutoFormat('<lora:fulllora:1> [<lora:partiallora:1>::0.5], 1girl', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
+
+            // Nested scheduling
+            expect(shouldAutoFormat('[red:[blue::0.7]:0.5] cat, 1girl', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
+        });
+
+
         test('should return true for text with "word + comma" pattern', () => {
             expect(shouldAutoFormat('1girl, blue hair,', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
             expect(shouldAutoFormat('tag1, tag2', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);

--- a/tests/js/auto-formatter.test.js
+++ b/tests/js/auto-formatter.test.js
@@ -41,6 +41,20 @@ describe('AutoFormatter Functions', () => {
             expect(shouldAutoFormat('X, 1.5, Y', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(false);
         });
 
+        test('should return false for JSON-like content (avoid corrupting JSON commas)', () => {
+            const jsonText = `{
+  "quality_meta_year_safe": "masterpiece, best quality, score_9, year 2025, safe",
+  "count": "1girl",
+  "artist": "{{artist}}",
+  "tags": "tag1, tag2",
+  "width": 1024
+}`;
+
+            // JSON contains many "word + comma" patterns inside string values,
+            // but it must never be auto-formatted as prompt tags.
+            expect(shouldAutoFormat(jsonText, mockNodeInfo('SimpleChatTextInput', 'text'))).toBe(false);
+        });
+
         test('should return true for text with "word + comma" pattern', () => {
             expect(shouldAutoFormat('1girl, blue hair,', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);
             expect(shouldAutoFormat('tag1, tag2', mockNodeInfo('CLIPTextEncode', 'text'))).toBe(true);

--- a/web/js/auto-formatter.js
+++ b/web/js/auto-formatter.js
@@ -1,6 +1,44 @@
 import { settingValues } from './settings.js';
 import { NodeInfo } from './node-info.js';
 
+/**
+ * Heuristic detection for JSON content.
+ *
+ * Autocomplete-Plus auto formatter is designed for prompt tags (comma-separated).
+ * If we format JSON, we will destroy structural commas like:
+ *   "key": "value",
+ *
+ * This function tries to detect JSON-ish textarea content and skip formatting.
+ * We intentionally treat "looks like JSON" as sufficient (no strict parse needed),
+ * because users may be in the middle of editing.
+ */
+function looksLikeJson(text) {
+    if (!text) return false;
+    const t = text.trim();
+    if (t.length < 2) return false;
+
+    const first = t[0];
+
+    // Object
+    if (first === '{') {
+        // Typical JSON key pattern: "key":
+        return /"[^"\n]+"\s*:/.test(t);
+    }
+
+    // Array (less strict, but still try to avoid false positives)
+    if (first === '[') {
+        const rest = t.slice(1);
+        if (/"[^"\n]*"/.test(t)) return true; // string elements
+        if (rest.includes('{')) return true; // object elements
+        if (rest.includes('[')) return true; // nested arrays
+        if (/\d/.test(rest)) return true; // numbers
+        if (/\b(true|false|null)\b/.test(rest)) return true; // JSON literals
+        return false;
+    }
+
+    return false;
+}
+
 
 /**
  * Determines if the text content should be auto-formatted.
@@ -8,10 +46,11 @@ import { NodeInfo } from './node-info.js';
  * Format conditions:
  * 1. Skip formatting if node is in blocklist
  * 2. If text is empty after trimming, format only if trimSurroundingSpaces is enabled, otherwise don't format
- * 3. Skip formatting if text contains only numbers or single letters (separated by commas)
- * 4. Format if text contains "word + comma" pattern
- * 5. Format if trimSurroundingSpaces is enabled and there are surrounding spaces or line breaks
- * 6. Otherwise, don't format
+ * 3. Skip formatting if text looks like JSON
+ * 4. Skip formatting if text contains only numbers or single letters (separated by commas)
+ * 5. Format if text contains "word + comma" pattern
+ * 6. Format if trimSurroundingSpaces is enabled and there are surrounding spaces or line breaks
+ * 7. Otherwise, don't format
  *
  * @param {NodeInfo} nodeInfo - The node information.
  * @returns {boolean} - True if the text should be formatted, false otherwise.
@@ -43,7 +82,12 @@ function shouldAutoFormat(text, nodeInfo) {
         return settingValues.trimSurroundingSpaces;
     }
 
-    // 3. Check if the text is purely numeric data or single-letter placeholders with commas
+    // 3. Skip JSON-like content (do not destroy JSON commas)
+    if (looksLikeJson(trimmedText)) {
+        return false;
+    }
+
+    // 4. Check if the text is purely numeric data or single-letter placeholders with commas
     // (e.g., "0,0,0,1,1,1" or "0.5, -1.2, 0.8" or "A,B,R" for LoRA Block Weight)
     const elements = trimmedText.split(',').map(el => el.trim());
     const isSingleLetterOrNumeric = elements.every(el => {
@@ -56,13 +100,13 @@ function shouldAutoFormat(text, nodeInfo) {
         return false; // Don't format numeric data or single-letter template patterns
     }
 
-    // 4. If text contains "word + comma" pattern, format it
+    // 5. If text contains "word + comma" pattern, format it
     const wordCommaPattern = /\w+\s*,/g;
     if (trimmedText.match(wordCommaPattern)) {
         return true;
     }
 
-    // 5. If trimSurroundingSpaces is enabled and there are surrounding spaces, format to trim them
+    // 6. If trimSurroundingSpaces is enabled and there are surrounding spaces, format to trim them
     if (settingValues.trimSurroundingSpaces && text !== trimmedText) {
         return true;
     }

--- a/web/js/auto-formatter.js
+++ b/web/js/auto-formatter.js
@@ -2,41 +2,23 @@ import { settingValues } from './settings.js';
 import { NodeInfo } from './node-info.js';
 
 /**
- * Heuristic detection for JSON content.
- *
- * Autocomplete-Plus auto formatter is designed for prompt tags (comma-separated).
- * If we format JSON, we will destroy structural commas like:
- *   "key": "value",
- *
- * This function tries to detect JSON-ish textarea content and skip formatting.
- * We intentionally treat "looks like JSON" as sufficient (no strict parse needed),
- * because users may be in the middle of editing.
+ * JSON content detection with actual parsing.
+ * 
+ * @param {string} text - The text to check for JSON content.
+ * @return {boolean} - True if the text is valid JSON, false otherwise.
  */
-function looksLikeJson(text) {
+function isJsonContent(text) {
     if (!text) return false;
     const t = text.trim();
     if (t.length < 2) return false;
+    if (t[0] !== '{' && t[0] !== '[') return false;
 
-    const first = t[0];
-
-    // Object
-    if (first === '{') {
-        // Typical JSON key pattern: "key":
-        return /"[^"\n]+"\s*:/.test(t);
-    }
-
-    // Array (less strict, but still try to avoid false positives)
-    if (first === '[') {
-        const rest = t.slice(1);
-        if (/"[^"\n]*"/.test(t)) return true; // string elements
-        if (rest.includes('{')) return true; // object elements
-        if (rest.includes('[')) return true; // nested arrays
-        if (/\d/.test(rest)) return true; // numbers
-        if (/\b(true|false|null)\b/.test(rest)) return true; // JSON literals
+    try {
+        JSON.parse(t);
+        return true;
+    } catch {
         return false;
     }
-
-    return false;
 }
 
 
@@ -46,7 +28,7 @@ function looksLikeJson(text) {
  * Format conditions:
  * 1. Skip formatting if node is in blocklist
  * 2. If text is empty after trimming, format only if trimSurroundingSpaces is enabled, otherwise don't format
- * 3. Skip formatting if text looks like JSON
+ * 3. Skip formatting if text is valid JSON
  * 4. Skip formatting if text contains only numbers or single letters (separated by commas)
  * 5. Format if text contains "word + comma" pattern
  * 6. Format if trimSurroundingSpaces is enabled and there are surrounding spaces or line breaks
@@ -82,8 +64,8 @@ function shouldAutoFormat(text, nodeInfo) {
         return settingValues.trimSurroundingSpaces;
     }
 
-    // 3. Skip JSON-like content (do not destroy JSON commas)
-    if (looksLikeJson(trimmedText)) {
+    // 3. Skip JSON content (do not destroy JSON commas)
+    if (isJsonContent(trimmedText)) {
         return false;
     }
 
@@ -101,7 +83,7 @@ function shouldAutoFormat(text, nodeInfo) {
     }
 
     // 5. If text contains "word + comma" pattern, format it
-    const wordCommaPattern = /\w+\s*,/g;
+    const wordCommaPattern = /[^\s,]+\s*,/g;
     if (trimmedText.match(wordCommaPattern)) {
         return true;
     }


### PR DESCRIPTION
## Summary
- Skip auto-formatting for JSON-like textarea content to avoid corrupting structural commas in JSON.
- Add a unit test covering JSON input.

## Why
Autocomplete-Plus auto-formatting is designed for comma-separated prompt tags. When users paste JSON into a multiline textarea (e.g. used as structured prompt schema), formatting on blur can remove JSON commas and break the JSON.

## Test plan
- npm test
