### PR TITLE
Fix: autocomplete popup mispositioned when textarea is scrolled (scro…

### DIFF
--- a/web/js/autocomplete.js
+++ b/web/js/autocomplete.js
@@ -866,8 +866,8 @@ class AutocompleteUI {
         const rect = element.getBoundingClientRect();
 
         // Adjust the coordinates to be relative to the viewport
-        coordinates.top = rect.top + element.scrollTop + coordinates.top;
-        coordinates.left = rect.left + element.scrollLeft + coordinates.left;
+        coordinates.top = rect.top - element.scrollTop + coordinates.top;
+        coordinates.left = rect.left - element.scrollLeft + coordinates.left;
 
         if (debug) {
             span.style.backgroundColor = "#aaa";


### PR DESCRIPTION
## Summary
The autocomplete suggestion list appears pinned to the bottom of the viewport instead of near the caret when the prompt textarea has been scrolled down.

## Root cause
In `#getCaretCoordinates()` (web/js/autocomplete.js), the viewport conversion *adds* the element's scroll offset instead of *subtracting* it.

`span.offsetTop` / `offsetLeft` are offsets in the element's content coordinate space. Converting them to viewport coordinates requires subtracting `element.scrollTop` / `scrollLeft`, but the current code adds them. As the textarea is scrolled down, the computed caret Y grows, so `#updatePosition()`'s vertical-collision logic falls back and places the list near the bottom of the screen.

## Fix
Before:
```
coordinates.top = rect.top + element.scrollTop + coordinates.top;
coordinates.left = rect.left + element.scrollLeft + coordinates.left;
```

After:
```
coordinates.top = rect.top - element.scrollTop + coordinates.top;
coordinates.left = rect.left - element.scrollLeft + coordinates.left;
```

This matches the reference implementation (component/textarea-caret-position), which subtracts the scroll offset.

## Reproduction
1. Scroll a prompt textarea down.
2. Trigger autocomplete. => The list appears at the bottom of the screen. With an unscrolled textarea it is positioned correctly.

## Verification
After the change, the popup tracks the caret regardless of scroll position. Tested on Windows. Frontend-version-independent: reproduced on both the latest and an older comfyui-frontend-package, so this is unrelated to #73.